### PR TITLE
Fix partial argument matching: seq(along=x) -> seq(along.with=x)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Biobase
 Title: Biobase: Base functions for Bioconductor
-Version: 2.45.0
+Version: 2.45.1
 Author: R. Gentleman, V. Carey, M. Morgan, S. Falcon
 Description: Functions that are needed by many other packages or which
         replace R functions.

--- a/R/VersionsClass.R
+++ b/R/VersionsClass.R
@@ -18,7 +18,7 @@ setMethod("initialize", signature(.Object="Versions"),
 
 .asValidVersions <- function(versions) {
     res <- list()
-    for (i in seq(along=versions))
+    for (i in seq(along.with=versions))
       res[i] <-
         if (!is.character(versions[[i]]) &&
             .isValidVersion(versions[[i]]))

--- a/R/strings.R
+++ b/R/strings.R
@@ -13,7 +13,7 @@ strbreak <- function(x, width=getOption("width"), exdent=2, collapse="\n") {
    ww <- width-exdent
    lb <- paste0(collapse, paste(rep(" ", exdent), collapse=""))
    rv <- character(length(x))
-   for(i in seq(along=x)) {
+   for(i in seq(along.with=x)) {
       first <- 1
       last  <- width
       if(nchar(x[i])>width) {

--- a/R/tools.R
+++ b/R/tools.R
@@ -92,7 +92,7 @@ copySubstitute = function(src, dest, symbolValues,
    ## cin and cout are single files or connections
    cpSubsCon = function(cin, cout) {
       txt = readLines(cin)
-      for (i in seq(along=symbolValues)) {
+      for (i in seq(along.with=symbolValues)) {
           txt = gsub(nm[i], symbolValues[[i]], txt, fixed=TRUE)
           if (any(is.na(txt)))
               stop("trying to replace ", nm[i], " by an NA")
@@ -116,7 +116,7 @@ copySubstitute = function(src, dest, symbolValues,
    ## Substitution on filenames
    subsFileName = function(x) {
       res = gsub(removeExtension, "", x)
-      for (i in seq(along=symbolValues)) {
+      for (i in seq(along.with=symbolValues)) {
          res = gsub(nm[i], symbolValues[[i]], res)
          if (any(is.na(res)))
              stop("trying to replace ", nm[i], " by an NA")
@@ -155,7 +155,7 @@ copySubstitute = function(src, dest, symbolValues,
             }
             ## process src
             isdir = file.info(src)$isdir
-            for (k in seq(along=src)) {
+            for (k in seq(along.with=src)) {
                ## name of source file or directory (without path)
                tmp  = unlist(strsplit(src[k], .Platform$file.sep))
                tmp  = subsFileName(tmp[length(tmp)])

--- a/R/vignettes.R
+++ b/R/vignettes.R
@@ -20,7 +20,7 @@ getPkgVigs = function(package=NULL) {
   
   ## construct data frame with: package, path, title
   pkgVigs = vector(mode="list", length=length(vigrds))
-  for(j in seq(along=vigrds)) {
+  for(j in seq(along.with=vigrds)) {
     if (file.exists(vigrds[j])) {
       v = readRDS(vigrds[j])
       f = v[, "PDF"]
@@ -98,7 +98,7 @@ addVigs2WinMenu = function(pkgName) {
       pkgMenu = paste("Vignettes", pkgName, sep="/")
       winMenuAdd(pkgMenu)
 
-      for (i in seq(along=vigs))
+      for (i in seq(along.with=vigs))
         winMenuAddItem(pkgMenu, names(vigs)[i],
                        paste0("shell.exec(\"", vigs[i], "\")"))
 


### PR DESCRIPTION
When using:
```r
options(warnPartialMatchArgs=TRUE)
```
the Biobase package produces:
```r
In seq.default(along = versions) :
   partial argument match of 'along' to 'along.with'
```
in many places.  This PR fixes that.