### PR TITLE
Fix suggests for data SW

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Authors@R: c(
         role = "cre",
         email = "maintainer@bioconductor.org"
     ))
-Suggests: tools, tkWidgets, ALL, RUnit, golubEsets, BiocStyle, knitr
+Suggests: tools, tkWidgets, ALL, RUnit, golubEsets, BiocStyle, knitr, limma
 Depends: R (>= 2.10), BiocGenerics (>= 0.27.1), utils
 Imports: methods
 VignetteBuilder: knitr


### PR DESCRIPTION
The r-universe build [is currently failing](https://github.com/r-universe/bioc/actions/runs/8455781918/job/23164106051) because `lemma` is needed to open one of the datasets, however it is not declared anywhere. 

```r
install.packages("Biobase", dependencies=TRUE)
data(SW, package = 'Biobase')
print(SW)
## Loading required package: limma
## Error in .requirePackage(package) :
##   unable to find required package ‘limma’
## In addition: Warning message:
## In library(package, lib.loc = lib.loc, character.only = TRUE, logical.return = TRUE,  :
##   there is no package called ‘limma’
```
It is good practice to put dependencies in Suggests that are needed for the full functionality of a package.
