### PR TITLE
adapt to STRICT_R_HEADERS requirement

### DIFF
--- a/src/envir.c
+++ b/src/envir.c
@@ -90,7 +90,7 @@ SEXP lc_prefix(SEXP x, SEXP ignoreCase)
 
     /* init to first char in first elem. of x */
     first = CHAR(STRING_ELT(x, 0));
-    prefix = (char *)Calloc(min_nc + 1, char);
+    prefix = (char *)R_Calloc(min_nc + 1, char);
     done = 0;
     i = 0;
     while (1) {
@@ -117,7 +117,7 @@ SEXP lc_prefix(SEXP x, SEXP ignoreCase)
     }
 
     ans = mkString(prefix);
-    Free(prefix);
+    R_Free(prefix);
     UNPROTECT(1);
     return ans;
 }


### PR DESCRIPTION
This fixes build errors with R-devel, which now build with `STRICT_R_HEADERS` by default and so don't make `Calloc` and `Free` available. See:

https://github.com/wch/r-source/commit/a236d4251db172a39910c8d5b9d3fba18ac57ec9

For reference, the build failure I had seen:

```
* installing *source* package ‘Biobase’ ...
** using staged installation
** libs
using C compiler: ‘gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0’
gcc -I"/opt/R/devel/lib/R/include" -DNDEBUG   -I/usr/local/include  -DSTRICT_R_HEADERS=1  -fpic  -g -O2  -c Rinit.c -o Rinit.o
gcc -I"/opt/R/devel/lib/R/include" -DNDEBUG   -I/usr/local/include  -DSTRICT_R_HEADERS=1  -fpic  -g -O2  -c anyMissing.c -o anyMissing.o
gcc -I"/opt/R/devel/lib/R/include" -DNDEBUG   -I/usr/local/include  -DSTRICT_R_HEADERS=1  -fpic  -g -O2  -c envir.c -o envir.o
envir.c: In function ‘lc_prefix’:
envir.c:93:22: warning: implicit declaration of function ‘Calloc’; did you mean ‘S_alloc’? [-Wimplicit-function-declaration]
   93 |     prefix = (char *)Calloc(min_nc + 1, char);
      |                      ^~~~~~
      |                      S_alloc
envir.c:93:41: error: expected expression before ‘char’
   93 |     prefix = (char *)Calloc(min_nc + 1, char);
      |                                         ^~~~
envir.c:120:5: warning: implicit declaration of function ‘Free’ [-Wimplicit-function-declaration]
  120 |     Free(prefix);
      |     ^~~~
make: *** [/opt/R/devel/lib/R/etc/Makeconf:195: envir.o] Error 1
ERROR: compilation failed for package ‘Biobase’
```